### PR TITLE
Improve CNF to 3-SAT conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,14 @@ git clone https://github.com/C2-Q/C2Q.git
 cd C2Q
 pip install -r requirements.txt
 ```
+
+### 🧪 Running Tests
+
+Run the unit tests with `pytest` after installing the dependencies:
+
+```bash
+PYTHONPATH=. pytest -q
+```
 ## 🤝 Contributing
 
 We welcome contributions from researchers, developers, and practitioners interested in quantum software engineering.

--- a/src/tests/unit/test_sat_to_3sat.py
+++ b/src/tests/unit/test_sat_to_3sat.py
@@ -1,0 +1,34 @@
+import copy
+import unittest
+from pysat.formula import CNF
+from src.reduction import sat_to_3sat, solve_all_cnf_solutions
+
+
+class SatTo3SatTests(unittest.TestCase):
+    def test_does_not_mutate_input(self):
+        cnf = CNF(from_clauses=[[1, 2, 3], [1, -2]])
+        original = copy.deepcopy(cnf.clauses)
+        _ = sat_to_3sat(cnf)
+        self.assertEqual(cnf.clauses, original)
+
+    def test_padding_of_short_clauses(self):
+        cnf = CNF(from_clauses=[[1], [-2, 3]])
+        converted = sat_to_3sat(cnf)
+        self.assertEqual(converted.clauses, [[1, 1, 1], [-2, 3, 3]])
+
+    def test_equivalent_solutions_and_clause_lengths(self):
+        cnf = CNF(from_clauses=[[1, 2, 3, 4], [-1, 2]])
+        expected = solve_all_cnf_solutions(cnf)
+        converted = sat_to_3sat(cnf)
+        actual = solve_all_cnf_solutions(converted)
+
+        num_vars = max(abs(l) for clause in cnf.clauses for l in clause)
+        proj = lambda sol: [lit for lit in sol if abs(lit) <= num_vars]
+
+        self.assertEqual(sorted(map(proj, expected)), sorted(map(proj, actual)))
+        for clause in converted.clauses:
+            self.assertEqual(len(clause), 3)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- support padding short clauses when converting CNF to 3-SAT
- ensure original CNF object isn't mutated
- document how to run the tests
- clarify and simplify sat_to_3sat
- pad Tseytin clauses to guarantee all output clauses have three literals
- add unit tests for sat_to_3sat
- refine sat_to_3sat implementation and test equivalence of all solutions

## Testing
- `PYTHONPATH=. pytest -q src/tests/unit/test_sat_to_3sat.py`
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'qiskit_aer')*

------
https://chatgpt.com/codex/tasks/task_b_68871da144108330aa5c64fef51660d6