### PR TITLE
Improve repository README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,32 @@
-# C2⟩Q⟩: Classical-to-Quantum Programming Framework
+# C2|Q>: Classical-to-Quantum Programming Framework
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
+[![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Python 3.10+](https://img.shields.io/badge/Python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![Status: Research Prototype](https://img.shields.io/badge/status-research--prototype-orange)]()
 
 ---
 
-## 🧭 Overview
+## Overview
 
-**C2⟩Q⟩** is a modular quantum software engineering framework that automates the full pipeline from classical problem specifications to quantum circuit generation and execution.
+**C2|Q>** is a modular quantum software engineering framework that automates the full pipeline from classical problem specifications to quantum circuit generation and execution.
 
 This repository accompanies the article:
 
-> **"C2⟩Q⟩: Bridging Classical Code and Quantum Execution via Automated Translation, Algorithm Selection, and Device Recommendation"**  
+> **"C2|Q>: Bridging Classical Code and Quantum Execution via Automated Translation, Algorithm Selection, and Device Recommendation"**
 > Submitted to *ACM Transactions on Software Engineering and Methodology (TOSEM), 2025.*
 
 ---
 
-## 🔍 Motivation
+## Table of Contents
+- [Features](#features)
+- [Architecture](#architecture)
+- [Getting Started](#getting-started)
+- [Running Tests](#running-tests)
+- [Contributing](#contributing)
+- [License](#license)
+- [Contact](#contact)
 
-Developing quantum software currently demands deep knowledge of quantum theory, circuit design, and hardware specifications. **C2⟩Q⟩** lowers this barrier by enabling classical developers to:
-
+## Features
 - Submit **standard Python code** describing a problem.
 - Automatically **parse**, **reduce**, and **translate** the problem into **Quantum-Compatible Formats (QCFs)**.
 - **Select suitable quantum algorithms** (e.g., QAOA, VQE, Grover).
@@ -29,83 +35,74 @@ Developing quantum software currently demands deep knowledge of quantum theory, 
 
 ---
 
-## 📐 Architecture
+## Architecture
 
 ![Framework Overview](./src/assets/classiq_flow.pdf)
 
-Refer to [`src/assets/classiq_flow.pdf`](/src/assets/classiq_flow.pdf) for detailed component diagrams and workflow explanations.
+Refer to [`src/assets/classiq_flow.pdf`](src/assets/classiq_flow.pdf) for detailed component diagrams and workflow explanations.
 
 ---
 
-## 🚀 Getting Started
+## Getting Started
 
-### 🔧 Prerequisites
-
+### Prerequisites
 - Python 3.10+
 - Git
 
-### 💻 Quickstart
-
+### Quickstart
 ```bash
 git clone https://github.com/C2-Q/C2Q.git
 cd C2Q
 pip install -r requirements.txt
 ```
 
-### 🧪 Running Tests
-
+### Running Tests
 Run the unit tests with `pytest` after installing the dependencies:
-
 ```bash
 PYTHONPATH=. pytest -q
 ```
-## 🤝 Contributing
-
-We welcome contributions from researchers, developers, and practitioners interested in quantum software engineering.
 
 ---
 
-## 🛠️ Development and Contribution Workflow
+## Contributing
+We welcome contributions from researchers, developers, and practitioners interested in quantum software engineering.
 
+### Development Workflow
 1. **Fork** the repository on GitHub.
-
-2. **Clone** your fork locally:
-
+2. **Clone** your fork and install dependencies:
    ```bash
    git clone https://github.com/YOUR_USERNAME/C2Q.git
    cd C2Q
-3. Set up a virtual environment (recommended):
+   python -m venv venv
+   source venv/bin/activate  # On Windows use venv\Scripts\activate
+   pip install -r requirements.txt
+   ```
+3. **Create** a feature branch:
+   ```bash
+   git checkout -b feature/my-feature
+   ```
+4. **Commit** your changes:
+   ```bash
+   git add .
+   git commit -m "Add explanation / fix bug / implement feature"
+   ```
+5. **Push** and open a pull request:
+   ```bash
+   git push origin feature/my-feature
+   ```
 
-    ```bash
-    python -m venv venv
-    source venv/bin/activate  # On Windows: venv\Scripts\activate
-    pip install -r requirements.txt
-4. Create a feature branch:
-    ```bash
-    git checkout -b feature/your-feature-name
-5. Make your changes and commit:
-
-    ```bash
-    git add .
-    git commit -m "Add explanation / fix bug / implement feature"
-6. Push and open a pull request:
-    ```bash
-    git push origin feature/your-feature-name
-   
-## 📋 Guidelines
+### Guidelines
 - Follow PEP8 coding conventions.
-
 - Document public functions and modules clearly.
-
 - Keep commits focused and descriptive.
-
 - Be respectful in discussions and code reviews.
 
-## 📬 Contact
-- For research collaboration or substantial contributions, contact the maintainer:
- 📧 boshuai.ye@oulu.fi
+---
 
+## License
+This project is licensed under the [Apache 2.0 License](LICENSE).
 
+## Contact
+For research collaboration or substantial contributions, contact the maintainer:
 
-
-
+📧 boshuai.ye@oulu.fi


### PR DESCRIPTION
## Summary
- revamp README with clearer section titles
- fix license badge and re-order content
- update brand name to `C2|Q>` instead of the previous arrow text

## Testing
- `pip install -q networkx pysat python-sat matplotlib`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pylatex')*


------
https://chatgpt.com/codex/tasks/task_b_68877b116f988330b696b642407c0594